### PR TITLE
fix: use get-helm-3 for latest helm in gcloud-cli

### DIFF
--- a/src/gcloud-cli/install.sh
+++ b/src/gcloud-cli/install.sh
@@ -38,10 +38,10 @@ if [ "$WITH_KUBECTL" != "none" ]; then
     cat "./${COMPLETION}rc/kubectl.${COMPLETION}rc" >>"${_REMOTE_USER_HOME}/.${COMPLETION}rc"
 fi
 
-# install helm https://github.com/helm/helm/issues/31417
+# install helm https://github.com/helm/helm/raw/main/scripts/get-helm-3
 if [ "$WITH_HELM" != "none" ]; then
     if [ "$WITH_HELM" = "latest" ]; then
-        curl -fsSL https://github.com/helm/helm/raw/main/scripts/get-helm-4 | bash
+        curl -fsSL https://github.com/helm/helm/raw/main/scripts/get-helm-3 | bash
     else
         curl -fsSL https://github.com/helm/helm/raw/main/scripts/get-helm-"${WITH_HELM}" | bash
     fi

--- a/test/gcloud-cli/install_kubectl_helm.sh
+++ b/test/gcloud-cli/install_kubectl_helm.sh
@@ -11,7 +11,7 @@ not() {
 # Definition specific tests
 check "check for gcloud" gcloud --version
 check "check for kubectl" kubectl version --client
-check "check for helm" helm version
+check "check for helm" helm version | grep 'Version:"v3'
 check "check for gcloud completion" diff "${HOME}/.zshrc" "${tmp}/zshrc/gcloud.zshrc" | cut -c 1 | not grep '>'
 check "check for kubectl completion" diff "${HOME}/.zshrc" "${tmp}/zshrc/kubectl.zshrc" | cut -c 1 | not grep '>'
 check "check for helm completion" diff "${HOME}/.zshrc" "${tmp}/zshrc/helm.zshrc" | cut -c 1 | not grep '>'

--- a/test/gcloud-cli/install_with_bash_completion.sh
+++ b/test/gcloud-cli/install_with_bash_completion.sh
@@ -11,7 +11,7 @@ not() {
 # Definition specific tests
 check "check for gcloud" gcloud --version
 check "check for kubectl" kubectl version --client
-check "check for helm" helm version
+check "check for helm" helm version | grep 'Version:"v3'
 check "check for gcloud bash completion" diff "${HOME}/.bashrc" "${tmp}/bashrc/gcloud.bashrc" | cut -c 1 | not grep '>'
 check "check for kubectl bash completion" diff "${HOME}/.bashrc" "${tmp}/bashrc/kubectl.bashrc" | cut -c 1 | not grep '>'
 check "check for helm bash completion" diff "${HOME}/.bashrc" "${tmp}/bashrc/helm.bashrc" | cut -c 1 | not grep '>'


### PR DESCRIPTION
Fix failing test-scenarios for gcloud-cli by using the stable get-helm-3 script instead of the non-existent get-helm-4 for `with-helm: "latest"`.

Closes #50

Generated with [Claude Code](https://claude.ai/code)