### PR TITLE
chore: update debian base image from deprecated vscode/devcontainers to devcontainers/base:debian

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Debian",
-    "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/base:debian",
     "postCreateCommand": "test -e ${containerWorkspaceFolder}/.devcontainer/entry.sh && zsh ${containerWorkspaceFolder}/.devcontainer/entry.sh",
     "remoteUser": "vscode",
     "mounts": [

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
         baseImage:
           - debian:latest
           - ubuntu:latest
-          - mcr.microsoft.com/vscode/devcontainers/base:0-bullseye
+          - mcr.microsoft.com/devcontainers/base:debian
           - mcr.microsoft.com/devcontainers/base:ubuntu
     steps:
       - uses: actions/checkout@v4

--- a/src/zsh-dotfiles/README.md
+++ b/src/zsh-dotfiles/README.md
@@ -18,7 +18,7 @@ Setup zsh-dotfiles
 | plugin-manager | used plugin manager (will be installed other feature) | string | without |
 | theme | used theme (will be installed other feature) | string | without |
 | with-plugins | if false, do not install zsh-completions, zsh-autosuggestions, and so on | boolean | false |
-| with-tools | if false, do not install zsh, git, sudo, exa, ripgrep and so on | boolean | false |
+| with-tools | if false, do not install zsh, git, sudo, eza, ripgrep and so on | boolean | false |
 | with-aliases | if false, do not set aliases | boolean | false |
 
 ## Customizations

--- a/src/zsh-dotfiles/devcontainer-feature.json
+++ b/src/zsh-dotfiles/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "zsh-dotfiles",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "name": "zsh-dotfiles",
     "documentationURL": "https://github.com/hayas1/devcontainer-features/tree/main/src/zsh-dotfiles",
     "description": "Setup zsh-dotfiles",
@@ -33,7 +33,7 @@
         "with-tools": {
             "type": "boolean",
             "default": false,
-            "description": "if false, do not install zsh, git, sudo, exa, ripgrep and so on"
+            "description": "if false, do not install zsh, git, sudo, eza, ripgrep and so on"
         },
         "with-aliases": {
             "type": "boolean",

--- a/src/zsh-dotfiles/home/aliases
+++ b/src/zsh-dotfiles/home/aliases
@@ -1,9 +1,9 @@
-if type exa >/dev/null 2>&1; then
-    alias ls='exa --git --icons'
-    alias la='exa -a --icons'
-    alias ll='exa -aal --icons'
-    alias lt='exa -T -L 3 -a -I "node_modules|.git|.cache" --icons'
-    alias ltl='exa -T -L 3 -a -I "node_modules|.git|.cache" -l --icons'
+if type eza >/dev/null 2>&1; then
+    alias ls='eza --git --icons'
+    alias la='eza -a --icons'
+    alias ll='eza -aal --icons'
+    alias lt='eza -T -L 3 -a -I "node_modules|.git|.cache" --icons'
+    alias ltl='eza -T -L 3 -a -I "node_modules|.git|.cache" -l --icons'
 fi
 if type batcat >/dev/null 2>&1; then
     alias cat='batcat --paging=never --style=header --theme=TwoDark'

--- a/src/zsh-dotfiles/install.sh
+++ b/src/zsh-dotfiles/install.sh
@@ -58,7 +58,7 @@ esac
 if [ "$WITH_TOOLS" = "true" ]; then
     apt-get update -y && apt-get upgrade -y &&
         apt-get install -y zsh wget git procps htop connect-proxy sudo \
-            exa ripgrep fd-find bat hexyl &&
+            eza ripgrep fd-find bat hexyl &&
         apt-get clean && rm -rf /var/lib/apt/lists
 fi
 

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -1,6 +1,6 @@
 {
     "all_powerlevel10k": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "zsh-dotfiles": {
                 "plugin-manager": "oh-my-zsh",
@@ -41,7 +41,7 @@
         }
     },
     "all_starship_sheldon": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "zsh-dotfiles": {
                 "plugin-manager": "sheldon",

--- a/test/gcloud-cli/scenarios.json
+++ b/test/gcloud-cli/scenarios.json
@@ -1,12 +1,12 @@
 {
     "install_only_gcloud": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "gcloud-cli": {}
         }
     },
     "install_kubectl_helm": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "gcloud-cli": {
                 "with-kubectl": "latest",
@@ -15,7 +15,7 @@
         }
     },
     "install_with_version": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "gcloud-cli": {
                 "version": "463.0.0-0",
@@ -25,7 +25,7 @@
         }
     },
     "install_with_bash_completion": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "gcloud-cli": {
                 "with-kubectl": "latest",

--- a/test/powerlevel10k/scenarios.json
+++ b/test/powerlevel10k/scenarios.json
@@ -1,6 +1,6 @@
 {
     "install_with_omz": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "powerlevel10k": {
                 "plugin-manager": "oh-my-zsh"
@@ -8,7 +8,7 @@
         }
     },
     "install_with_sheldon": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "ghcr.io/hayas1/devcontainer-features/sheldon": {},
             "powerlevel10k": {
@@ -17,7 +17,7 @@
         }
     },
     "install_with_version": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "powerlevel10k": {
                 "version": "v1.18.0"

--- a/test/pyenv/scenarios.json
+++ b/test/pyenv/scenarios.json
@@ -1,6 +1,6 @@
 {
     "install_with_latest_python": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "pyenv": {
                 "version": "latest",
@@ -9,7 +9,7 @@
         }
     },
     "install_with_python37": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "pyenv": {
                 "version": "master",
@@ -18,7 +18,7 @@
         }
     },
     "install_without_python": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "pyenv": {
                 "version": "master",
@@ -27,7 +27,7 @@
         }
     },
     "install_with_bashrc": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "pyenv": {
                 "rc-file": ".bashrc"

--- a/test/sheldon/scenarios.json
+++ b/test/sheldon/scenarios.json
@@ -1,6 +1,6 @@
 {
     "install_with_zshrc": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "sheldon": {
                 "rc-file": ".zshrc"
@@ -8,7 +8,7 @@
         }
     },
     "install_with_bashrc_fixed": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "sheldon": {
                 "version": "0.7.2",

--- a/test/starship/scenarios.json
+++ b/test/starship/scenarios.json
@@ -1,6 +1,6 @@
 {
     "install_with_zshrc": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "starship": {
                 "rc-file": ".zshrc"
@@ -8,7 +8,7 @@
         }
     },
     "install_with_bashrc": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "starship": {
                 "rc-file": ".bashrc"

--- a/test/tfenv/scenarios.json
+++ b/test/tfenv/scenarios.json
@@ -1,6 +1,6 @@
 {
     "install_with_latest_terraform": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "tfenv": {
                 "version": "latest",
@@ -9,7 +9,7 @@
         }
     },
     "install_without_terraform": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "tfenv": {
                 "version": "master",

--- a/test/zsh-dotfiles/install_p10k_omz.sh
+++ b/test/zsh-dotfiles/install_p10k_omz.sh
@@ -11,7 +11,7 @@ not() {
 }
 
 # Definition specific tests
-check "install exa" exa --version
+check "install eza" eza --version
 check "install ripgrep" rg --version
 check "copy p10k.zsh" diff "${HOME}/.p10k.zsh" "${tmp}/home/p10k.zsh"
 check "not copy starship.toml" not test -e "${HOME}/.config/starship.toml"

--- a/test/zsh-dotfiles/install_p10k_theme_only.sh
+++ b/test/zsh-dotfiles/install_p10k_theme_only.sh
@@ -12,7 +12,7 @@ not() {
 
 # Definition specific tests
 check "copy p10k.zsh" diff "${HOME}/.p10k.zsh" "${tmp}/home/p10k.zsh"
-check "not install exa" not type exa >/dev/null
+check "not install eza" not type eza >/dev/null
 check "not install ripgrep" not type rg >/dev/null
 check "not copy starship.toml" not test -e "${HOME}/.config/starship.toml"
 check "not copy sheldon/plugins.toml" not test -e "${HOME}/.config/sheldon/plugins.toml"

--- a/test/zsh-dotfiles/install_starship_sheldon.sh
+++ b/test/zsh-dotfiles/install_starship_sheldon.sh
@@ -11,7 +11,7 @@ not() {
 }
 
 # Definition specific tests
-check "install exa" exa --version
+check "install eza" eza --version
 check "install ripgrep" rg --version
 check "copy starship.toml" diff "${HOME}/.config/starship.toml" "${tmp}/home/config/starship.toml"
 check "copy sheldon/plugins.toml" diff "${HOME}/.config/sheldon/plugins.toml" "${tmp}/home/config/sheldon/plugins.toml"

--- a/test/zsh-dotfiles/scenarios.json
+++ b/test/zsh-dotfiles/scenarios.json
@@ -1,6 +1,6 @@
 {
     "install_p10k_omz": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "zsh-dotfiles": {
                 "plugin-manager": "oh-my-zsh",
@@ -12,7 +12,7 @@
         }
     },
     "install_starship_sheldon": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "zsh-dotfiles": {
                 "plugin-manager": "sheldon",
@@ -24,7 +24,7 @@
         }
     },
     "install_p10k_theme_only": {
-        "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "zsh-dotfiles": {
                 "plugin-manager": "without",


### PR DESCRIPTION
Replace `mcr.microsoft.com/vscode/devcontainers/base:0-bullseye` (deprecated,
Debian 11 Bullseye) with `mcr.microsoft.com/devcontainers/base:debian` (current
maintained image) across all scenarios.json, test.yaml, and devcontainer.json.

https://claude.ai/code/session_015uzu4jc7SSudzdKiQodhKJ