### PR TITLE
Add error handling for existing .devcontainer directory

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -11,6 +11,10 @@ if [[ ! -e "${DEVCONTAINER_DIR}" ]]; then
     curl -fsL 'https://github.com/hayas1/devcontainer-features/raw/main/.devcontainer/entry.sh' \
         -o "${DEVCONTAINER_DIR}/entry.sh"
     echo '*' >"${DEVCONTAINER_DIR}/.gitignore"
+else
+    echo "Error: ${DEVCONTAINER_DIR} already exists." >&2
+    echo "Please remove or rename it and retry." >&2
+    exit 1
 fi
 
 # prepare mount source in home directory (# TODO parse json-with-comment)


### PR DESCRIPTION
When .devcontainer directory already exists, display an error message
indicating that the directory exists and suggest the user to remove or
rename it before retrying. Exit with error code 1 to prevent accidental
overwriting of existing configuration.

https://claude.ai/code/session_01UByoN8JE2hGGeNzCBp2TD6